### PR TITLE
Optionally purge cloudflare cache on update

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	ListenAddress string `yaml:"listen_address"`
 	PublicURL     string `yaml:"public_url"`
 
+	CloudflareZoneID string `yaml:"cloudflare_zone_id"`
+	CloudflareToken  string `yaml:"cloudflare_token"`
+
 	Feeds         map[string]*FeedConfig `yaml:"feeds"`
 	feedsByRoomID map[id.RoomID]*FeedConfig
 


### PR DESCRIPTION
This should enable us to tell cloudflare to cache feedserv JSON/etc responses for as long as possible and clear the cache as updates are received.